### PR TITLE
Version 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ This is a plugin for the [Cheshire Cat Project](https://github.com/pieroit/chesh
 
 # Usage
 
-After plugin installation you need to type `scrapycat` followed by the website URL.
+After plugin installation you need to type `@scrapycat` followed by the website URL.
 
 You can specify a base path in the URL to only process pages under that path:
-- `scrapycat www.dominio.it` - processes all pages on the site
-- `scrapycat www.dominio.it/pippo` - only processes pages under the /pippo path
+- `@scrapycat www.dominio.it` - processes all pages on the site
+- `@scrapycat www.dominio.it/pippo` - only processes pages under the /pippo path
 
 The ingest phase may be long, you need to wait for the cat's response with the number of URLs/PDFs successfully ingested. If some URLs fail to be ingested (due to server disconnections or other errors), the plugin will continue processing the remaining URLs and report how many were successful.
 
@@ -18,6 +18,10 @@ On the plugin settings you can set:
 
 - **Ingest PDF**: If this setting is enabled, the plugin will also ingest PDFs found on the website.
 - **Skip GET Parameters**: If this setting is enabled, the plugin will skip URLs that contain GET parameters (URLs with a question mark, like "example.com/page?param=value"). This is useful to avoid duplicate content and prevent crawling dynamic pages that might generate infinite loops.
+- **Max Depth**: Controls how many levels of links the scraper will follow from the starting page.  
+- `-1`: No limit (standard behavior). The scraper will follow all nested links and crawl the entire site.  
+- `0`: Only the starting page is processed; no links are followed.  
+- `N > 0`: The scraper will follow links up to N levels deep from the starting page.
 
 # Examples
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ On the plugin settings you can set:
 - **Ingest PDF**: If this setting is enabled, the plugin will also ingest PDFs found on the website.
 - **Skip GET Parameters**: If this setting is enabled, the plugin will skip URLs that contain GET parameters (URLs with a question mark, like "example.com/page?param=value"). This is useful to avoid duplicate content and prevent crawling dynamic pages that might generate infinite loops.
 - **Max Depth**: Controls how many levels of links the scraper will follow from the starting page.  
-- `-1`: No limit (standard behavior). The scraper will follow all nested links and crawl the entire site.  
-- `0`: Only the starting page is processed; no links are followed.  
-- `N > 0`: The scraper will follow links up to N levels deep from the starting page.
+    - `-1`: No limit (standard behavior). The scraper will follow all nested links and crawl the entire site.  
+    - `0`: Only the starting page is processed; no links are followed.  
+    - `N > 0`: The scraper will follow links up to N levels deep from the starting page.
+- **Allowed Extra Roots**: A comma-separated list of additional root URLs that the scraper is allowed to follow if found while crawling from the starting url. This is useful for sites with multiple subdomains or (un)related domains.
 
 # Examples
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ On the plugin settings you can set:
     - `-1`: No limit (standard behavior). The scraper will follow all nested links and crawl the entire site.  
     - `0`: Only the starting page is processed; no links are followed.  
     - `N > 0`: The scraper will follow links up to N levels deep from the starting page.
+- **Max Pages**: Controls the maximum number of pages to crawl.  
+    - `-1`: No limit (standard behavior). The scraper will follow all links until there are no more to follow.  
+    - `N > 0`: The scraper will stop after crawling N pages.
 - **Allowed Extra Roots**: A comma-separated list of additional root URLs that the scraper is allowed to follow if found while crawling from the starting url. This is useful for sites with multiple subdomains or (un)related domains.
 
 # Examples

--- a/plugin.json
+++ b/plugin.json
@@ -5,6 +5,6 @@
   "author_url": "https://www.teamsviluppo.it/",
   "plugin_url": "https://github.com/team-sviluppo/cc_scrapycat",
   "thumb": "https://raw.githubusercontent.com/team-sviluppo/cc_scrapycat/396e82308648ffe1e3e6acd934f0c9e4adc41348/scrapycatlogo.png",
-  "tags": "plugins, prompt",
-  "version": "1.0.0"
+  "tags": "plugins, prompt, scraping, crawling",
+  "version": "1.1.0"
 }

--- a/scrapycat.py
+++ b/scrapycat.py
@@ -1,65 +1,58 @@
-from cat.mad_hatter.decorators import tool, hook
+from cat.mad_hatter.decorators import hook
 from typing import Dict
 from cat.log import log
 from bs4 import BeautifulSoup
 import requests
-import re
+import urllib.parse
 
-internal_links = []  # List of internal URLs on the site
-visited_pages = []  # List of visited pages during crawling
-queue = []  # Queue of unexplored pages
-root_url = ""  # Root URL of the site
-ingest_pdf = False
-skip_get_params = False  # Skip URLs with GET parameters
-base_path = ""  # Base path for URL filtering
+class ScrapyCatContext:
+    def __init__(self):
+        self.internal_links = []  # List of internal URLs on the site
+        self.visited_pages = []  # List of visited pages during crawling
+        self.queue = []  # Queue of unexplored pages
+        self.root_url = ""  # Root URL of the site
+        self.ingest_pdf = False
+        self.skip_get_params = False  # Skip URLs with GET parameters
+        self.base_path = ""  # Base path for URL filtering
+        self.max_depth = 0  # Max recursion depth
 
 
 @hook(priority=10)
 def agent_fast_reply(fast_reply, cat) -> Dict:
-    global root_url, ingest_pdf, skip_get_params, base_path, internal_links, visited_pages, queue
     settings = cat.mad_hatter.get_plugin().load_settings()
-    if settings["ingest_pdf"]:
-        ingest_pdf = True
-    else:
-        ingest_pdf = False
-    if settings["skip_get_params"]:
-        skip_get_params = True
-    else:
-        skip_get_params = False
+
+    ctx = ScrapyCatContext()
+    ctx.ingest_pdf = settings["ingest_pdf"]
+    ctx.skip_get_params = settings["skip_get_params"]
+    ctx.max_depth = settings["max_depth"]
+
     return_direct = False
     # Get user message
     user_message = cat.working_memory["user_message_json"]["text"]
 
     if user_message.startswith("scrapycat"):
-        # Reset all global variables to ensure a clean state for each run
-        internal_links = []
-        visited_pages = []
-        queue = []
-        base_path = ""
-        root_url = ""
-        skip_get_params = False  # Reset to default, will be updated from settings
+        # Reset context for each run
         full_url = user_message.split(" ")[1]
         if full_url.endswith("/"):
             full_url = full_url[:-1]
 
         # Extract base path from URL if present
-        import urllib.parse
         parsed_url = urllib.parse.urlparse(full_url)
-        base_path = parsed_url.path
+        ctx.base_path = parsed_url.path
 
         # Set root_url to just the scheme and netloc (domain)
-        root_url = f"{parsed_url.scheme}://{parsed_url.netloc}"
+        ctx.root_url = f"{parsed_url.scheme}://{parsed_url.netloc}"
 
-        crawler(root_url)
+        crawler(ctx, ctx.root_url)
         successful_imports = 0
-        for link in internal_links:
+        for link in ctx.internal_links:
             try:
                 cat.rabbit_hole.ingest_file(cat, link, 400, 100)
                 successful_imports += 1
             except Exception as e:
                 log.error(f"Error ingesting {link}: {str(e)}")
         return_direct = True
-        response = f"{successful_imports} of {len(internal_links)} URLs successfully imported in rabbit hole!"
+        response = f"{successful_imports} of {len(ctx.internal_links)} URLs successfully imported in rabbit hole!"
 
     # Manage response
     if return_direct:
@@ -68,11 +61,10 @@ def agent_fast_reply(fast_reply, cat) -> Dict:
     return fast_reply
 
 
-def crawler(page):
+def crawler(ctx: ScrapyCatContext, page):
     """Crawls a webpage to find its internal/external linked URLs."""
-    global internal_links, visited_pages, queue, root_url, ingest_pdf, base_path
     try:
-        if page.startswith("/") or page.startswith(f"{root_url}"):
+        if page.startswith("/") or page.startswith(f"{ctx.root_url}"):
 
             log.warning("Crawling page: " + page)
             headers = {
@@ -86,18 +78,18 @@ def crawler(page):
                 if "#" in url:
                     # anchor link
                     continue
-                if url.startswith("/") or url.startswith(f"{root_url}"):
+                if url.startswith("/") or url.startswith(f"{ctx.root_url}"):
                     if url.startswith("/"):
-                        new_url = f"{root_url}{url}"
+                        new_url = f"{ctx.root_url}{url}"
                     else:
                         new_url = url
-                    if new_url not in internal_links:
+                    if new_url not in ctx.internal_links:
                         # Check if URL matches the base path filter (if set)
-                        if base_path and not new_url.replace(root_url, "").startswith(base_path):
+                        if ctx.base_path and not new_url.replace(ctx.root_url, "").startswith(ctx.base_path):
                             continue
 
                         # Skip URLs with GET parameters if the setting is enabled
-                        if skip_get_params and "?" in new_url:
+                        if ctx.skip_get_params and "?" in new_url:
                             continue
 
                         # Skip image URLs and zip files
@@ -105,26 +97,26 @@ def crawler(page):
                             continue
                         # Handle PDFs based on settings
                         elif new_url.endswith(".pdf"):
-                            if ingest_pdf:
-                                internal_links.append(new_url)
+                            if ctx.ingest_pdf:
+                                ctx.internal_links.append(new_url)
                         else:
-                            internal_links.append(new_url)
+                            ctx.internal_links.append(new_url)
                 else:
                     # external link
                     continue
 
-            for i in range(len(internal_links)):
+            for i in range(len(ctx.internal_links)):
                 if (
-                    internal_links[i] not in visited_pages
-                    and internal_links[i] not in queue
+                    ctx.internal_links[i] not in ctx.visited_pages
+                    and ctx.internal_links[i] not in ctx.queue
                 ):
-                    queue.append(internal_links[i])
+                    ctx.queue.append(ctx.internal_links[i])
 
-            while len(queue) > 0:
-                next_url = queue.pop()
-                if next_url not in visited_pages:
-                    visited_pages.append(next_url)
-                    crawler(next_url)
+            while len(ctx.queue) > 0:
+                next_url = ctx.queue.pop()
+                if next_url not in ctx.visited_pages:
+                    ctx.visited_pages.append(next_url)
+                    crawler(ctx, next_url)
 
     except Exception as e:
         pass

--- a/scrapycat.py
+++ b/scrapycat.py
@@ -17,7 +17,7 @@ class ScrapyCatContext:
         self.ingest_pdf: bool = False      # Whether to ingest PDFs
         self.skip_get_params: bool = False # Skip URLs with GET parameters
         self.base_path: str = ""          # Base path for URL filtering
-        self.max_depth: int = 0           # Max recursion/crawling depth (-1 for unlimited)
+        self.max_depth: int = -1           # Max recursion/crawling depth (-1 for unlimited)
         self.max_pages: int = -1          # Max pages to crawl (-1 for unlimited)   
         self.allowed_extra_roots: Set[str] # Set of allowed root URLs for filtering
 

--- a/scrapycat.py
+++ b/scrapycat.py
@@ -1,26 +1,30 @@
 from cat.mad_hatter.decorators import hook
-from typing import Dict
+from typing import Dict, Set, Tuple
 from cat.log import log
 from bs4 import BeautifulSoup
 import requests
 import urllib.parse
+from cat.looking_glass.stray_cat import StrayCat
+from queue import Queue
 
 class ScrapyCatContext:
-    def __init__(self):
-        self.internal_links = []  # List of internal URLs on the site
-        self.visited_pages = []  # List of visited pages during crawling
-        self.queue = []  # Queue of unexplored pages
-        self.root_url = ""  # Root URL of the site
-        self.ingest_pdf = False
-        self.skip_get_params = False  # Skip URLs with GET parameters
-        self.base_path = ""  # Base path for URL filtering
-        self.max_depth = 0  # Max recursion depth
+    def __init__(self) -> None:
+        self.internal_links: Set[str] = set()  # Set of internal URLs on the site (unique)
+        self.visited_pages: Set[str] = set()   # Set of visited pages during crawling
+        self.queue: Queue[Tuple[str, int]] = Queue()  # Queue of (url, depth) tuples for BFS
+        self.root_url: str = ""           # Root URL of the site
+        self.ingest_pdf: bool = False      # Whether to ingest PDFs
+        self.skip_get_params: bool = False # Skip URLs with GET parameters
+        self.base_path: str = ""          # Base path for URL filtering
+        self.max_depth: int = 0           # Max recursion/crawling depth
 
 
 @hook(priority=10)
-def agent_fast_reply(fast_reply, cat) -> Dict:
+def agent_fast_reply(fast_reply: Dict, cat: StrayCat) -> Dict:
+
     settings = cat.mad_hatter.get_plugin().load_settings()
 
+    # Initialize context for this run
     ctx = ScrapyCatContext()
     ctx.ingest_pdf = settings["ingest_pdf"]
     ctx.skip_get_params = settings["skip_get_params"]
@@ -28,10 +32,10 @@ def agent_fast_reply(fast_reply, cat) -> Dict:
 
     return_direct = False
     # Get user message
-    user_message = cat.working_memory["user_message_json"]["text"]
+    user_message: str = cat.working_memory["user_message_json"]["text"]
 
-    if user_message.startswith("scrapycat"):
-        # Reset context for each run
+    if user_message.startswith("@scrapycat"):
+
         full_url = user_message.split(" ")[1]
         if full_url.endswith("/"):
             full_url = full_url[:-1]
@@ -43,8 +47,11 @@ def agent_fast_reply(fast_reply, cat) -> Dict:
         # Set root_url to just the scheme and netloc (domain)
         ctx.root_url = f"{parsed_url.scheme}://{parsed_url.netloc}"
 
+        # Start crawling from the root URL
         crawler(ctx, ctx.root_url)
         successful_imports = 0
+
+        # Ingest all found internal links
         for link in ctx.internal_links:
             try:
                 cat.rabbit_hole.ingest_file(cat, link, 400, 100)
@@ -52,7 +59,7 @@ def agent_fast_reply(fast_reply, cat) -> Dict:
             except Exception as e:
                 log.error(f"Error ingesting {link}: {str(e)}")
         return_direct = True
-        response = f"{successful_imports} of {len(ctx.internal_links)} URLs successfully imported in rabbit hole!"
+        response: str = f"{successful_imports} of {len(ctx.internal_links)} URLs successfully imported in rabbit hole!"
 
     # Manage response
     if return_direct:
@@ -61,62 +68,83 @@ def agent_fast_reply(fast_reply, cat) -> Dict:
     return fast_reply
 
 
-def crawler(ctx: ScrapyCatContext, page):
-    """Crawls a webpage to find its internal/external linked URLs."""
-    try:
-        if page.startswith("/") or page.startswith(f"{ctx.root_url}"):
+def crawler(ctx: ScrapyCatContext, start_url: str) -> None:
+    """
+    Crawls a webpage to find its internal/external linked URLs using BFS.
+    - Only internal links are followed.
+    - Skips images, archives, and optionally GET params.
+    - Handles PDFs based on settings.
+    - Respects max_depth:
+        - max_depth == -1: unlimited crawling (default behavior)
+        - max_depth == 0: only analyze the starting link
+        - max_depth > 0: crawl up to max_depth levels
+    """
+    
 
-            log.warning("Crawling page: " + page)
-            headers = {
-                "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:55.0) Gecko/20100101 Firefox/55.0",
-            }
-            response = requests.get(page, headers=headers).text
-            soup = BeautifulSoup(response, "html.parser")
-            urls = [link["href"] for link in soup.select("a[href]")]
+    ctx.queue = Queue()
+    ctx.queue.put((start_url, 0))  # (url, depth)
 
-            for url in urls:
-                if "#" in url:
-                    # anchor link
-                    continue
-                if url.startswith("/") or url.startswith(f"{ctx.root_url}"):
-                    if url.startswith("/"):
-                        new_url = f"{ctx.root_url}{url}"
-                    else:
-                        new_url = url
-                    if new_url not in ctx.internal_links:
-                        # Check if URL matches the base path filter (if set)
-                        if ctx.base_path and not new_url.replace(ctx.root_url, "").startswith(ctx.base_path):
-                            continue
+    while not ctx.queue.empty():
+        page, depth = ctx.queue.get()
+        if page in ctx.visited_pages:
+            continue
+        ctx.visited_pages.add(page)
 
-                        # Skip URLs with GET parameters if the setting is enabled
-                        if ctx.skip_get_params and "?" in new_url:
-                            continue
+        # Handle max_depth logic
+        # -1: unlimited, 0: only starting link, >0: up to max_depth
+        if ctx.max_depth != -1 and depth > ctx.max_depth:
+            continue
 
-                        # Skip image URLs and zip files
-                        if new_url.lower().endswith(('.jpg', '.jpeg', '.png', '.gif', '.bmp', '.svg', '.webp', '.ico', '.zip')):
-                            continue
-                        # Handle PDFs based on settings
-                        elif new_url.endswith(".pdf"):
-                            if ctx.ingest_pdf:
-                                ctx.internal_links.append(new_url)
-                        else:
-                            ctx.internal_links.append(new_url)
-                else:
-                    # external link
-                    continue
+        try:
+            # Only crawl internal pages (relative or under root_url)
+            if page.startswith("/") or page.startswith(f"{ctx.root_url}"):
+                log.warning("Crawling page: " + page)
+                headers = {
+                    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:55.0) Gecko/20100101 Firefox/55.0",
+                }
+                response = requests.get(page, headers=headers).text
+                soup = BeautifulSoup(response, "html.parser")
+                urls = [link["href"] for link in soup.select("a[href]")]
 
-            for i in range(len(ctx.internal_links)):
-                if (
-                    ctx.internal_links[i] not in ctx.visited_pages
-                    and ctx.internal_links[i] not in ctx.queue
-                ):
-                    ctx.queue.append(ctx.internal_links[i])
+                for url in urls:
+                    if "#" in url:
+                        # Skip anchor links
+                        continue
+                    # Normalize URL (handles relative and absolute)
+                    new_url = urllib.parse.urljoin(ctx.root_url, url)
+                    if not new_url.startswith(ctx.root_url):
+                        # External link
+                        # TODO ADD A SETTING TO DECIDE IF IGNORE OR NOT
+                        continue
 
-            while len(ctx.queue) > 0:
-                next_url = ctx.queue.pop()
-                if next_url not in ctx.visited_pages:
-                    ctx.visited_pages.append(next_url)
-                    crawler(ctx, next_url)
+                    # Check if URL matches the base path filter (if set)
+                    if ctx.base_path and not new_url.replace(ctx.root_url, "").startswith(ctx.base_path):
+                        continue
 
-    except Exception as e:
-        pass
+                    # Skip URLs with GET parameters if the setting is enabled
+                    if ctx.skip_get_params and "?" in new_url:
+                        continue
+
+                    # Skip image URLs and zip files
+                    if new_url.lower().endswith(('.jpg', '.jpeg', '.png', '.gif', '.bmp', '.svg', '.webp', '.ico', '.zip')):
+                        continue
+
+                    # Handle PDFs based on settings
+                    if new_url.endswith(".pdf"):
+                        if ctx.ingest_pdf:
+                            ctx.internal_links.add(new_url)
+                        continue
+
+                    # Add to internal links set
+                    ctx.internal_links.add(new_url)
+                    # Only queue for crawling if:
+                    # - max_depth == -1 (unlimited)
+                    # - or next depth <= max_depth
+                    # - and not already visited
+                    if (
+                        (ctx.max_depth == -1 or depth + 1 <= ctx.max_depth)
+                        and new_url not in ctx.visited_pages
+                    ):
+                        ctx.queue.put((new_url, depth + 1))
+        except Exception as e:
+            log.warning(f"Error crawling {page}: {e}")

--- a/settings.json
+++ b/settings.json
@@ -1,5 +1,5 @@
 {
     "ingest_pdf": true,
     "skip_get_params": false,
-    "max_depth": 0
+    "max_depth": 1
 }

--- a/settings.json
+++ b/settings.json
@@ -1,4 +1,5 @@
 {
     "ingest_pdf": true,
-    "skip_get_params": false
+    "skip_get_params": false,
+    "max_depth": -1
 }

--- a/settings.json
+++ b/settings.json
@@ -1,5 +1,5 @@
 {
     "ingest_pdf": true,
     "skip_get_params": false,
-    "max_depth": -1
+    "max_depth": 0
 }

--- a/settings.json
+++ b/settings.json
@@ -2,5 +2,5 @@
     "ingest_pdf": true,
     "skip_get_params": false,
     "max_depth": 0,
-    "allowed_roots": ""
+    "allowed_extra_roots": ""
 }

--- a/settings.json
+++ b/settings.json
@@ -1,6 +1,7 @@
 {
     "ingest_pdf": true,
     "skip_get_params": false,
-    "max_depth": 0,
+    "max_depth": -1,
+    "max_pages": -1,
     "allowed_extra_roots": ""
 }

--- a/settings.json
+++ b/settings.json
@@ -1,5 +1,6 @@
 {
     "ingest_pdf": true,
     "skip_get_params": false,
-    "max_depth": 1
+    "max_depth": 0,
+    "allowed_roots": ""
 }

--- a/settings.py
+++ b/settings.py
@@ -8,7 +8,7 @@ class PluginSettings(BaseModel):
     ingest_pdf: bool = False
     skip_get_params: bool = False
     max_depth: int = 0
-    allowed_roots: str = ""  # Comma-separated list of allowed root URLs
+    allowed_extra_roots: str = ""  # Comma-separated list of allowed root URLs
 
 
 # hook to give the cat settings

--- a/settings.py
+++ b/settings.py
@@ -8,6 +8,7 @@ class PluginSettings(BaseModel):
     ingest_pdf: bool = False
     skip_get_params: bool = False
     max_depth: int = 0
+    max_pages: int = -1
     allowed_extra_roots: str = ""  # Comma-separated list of allowed root URLs
 
 

--- a/settings.py
+++ b/settings.py
@@ -7,7 +7,8 @@ from enum import Enum
 class PluginSettings(BaseModel):
     ingest_pdf: bool = False
     skip_get_params: bool = False
-    max_depth: int
+    max_depth: int = 0
+    allowed_roots: str = ""  # Comma-separated list of allowed root URLs
 
 
 # hook to give the cat settings

--- a/settings.py
+++ b/settings.py
@@ -7,6 +7,7 @@ from enum import Enum
 class PluginSettings(BaseModel):
     ingest_pdf: bool = False
     skip_get_params: bool = False
+    max_depth: int
 
 
 # hook to give the cat settings

--- a/settings.py
+++ b/settings.py
@@ -7,7 +7,7 @@ from enum import Enum
 class PluginSettings(BaseModel):
     ingest_pdf: bool = False
     skip_get_params: bool = False
-    max_depth: int = 0
+    max_depth: int = -1
     max_pages: int = -1
     allowed_extra_roots: str = ""  # Comma-separated list of allowed root URLs
 


### PR DESCRIPTION
## Changelog 
- added setting `max_depth` in settings, controlling how many levels of links the scraper will follow from the starting page (if set to `-1` we have the old behavior)
- added setting `max_pages` in settings, controlling the maximum number of pages to crawl  (if set to `-1` we have the old behavior)
- added setting `allowed_extra_roots`, as an "allowed-list" of domains different from the starting one that we still want to scrape
- updated  the global variables handling by wrapping them in a context object `ScrapyCatContext`
- updated the typing of some `list` to `set`
- other minor changes